### PR TITLE
Use repo provided protoc.

### DIFF
--- a/docker/object_detection/Dockerfile
+++ b/docker/object_detection/Dockerfile
@@ -29,7 +29,7 @@ FROM tensorflow/tensorflow:1.15.5
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install -y python python-tk git curl unzip
+    apt-get install -y protobuf-compiler python python-tk git curl unzip
 
 # Get the tensorflow models research directory, and move it into tensorflow
 # source folder to match recommendation of installation
@@ -49,13 +49,6 @@ RUN pip install Cython && \
     pip install lxml && \
     pip install jupyter && \
     pip install matplotlib
-
-# Get protoc 3.0.0, rather than the old version already in the container
-RUN curl -OL "https://github.com/google/protobuf/releases/download/v3.0.0/protoc-3.0.0-linux-x86_64.zip" && \
-    unzip protoc-3.0.0-linux-x86_64.zip -d proto3 && \
-    mv proto3/bin/* /usr/local/bin && \
-    mv proto3/include/* /usr/local/include && \
-    rm -rf proto3 protoc-3.0.0-linux-x86_64.zip
 
 # Install pycocoapi
 RUN git clone --depth 1 https://github.com/cocodataset/cocoapi.git && \


### PR DESCRIPTION
In Ubuntu 18.04 (what is used for TF 1.15.5 container), Canonical ships 3.0.0 for the protobuf compiler. So downloading the zip is unnecessary. https://packages.ubuntu.com/bionic/protobuf-compiler