### PR TITLE
Fix issue with files containing jpg

### DIFF
--- a/retrain_efficientdet_model_maker_tf2.ipynb
+++ b/retrain_efficientdet_model_maker_tf2.ipynb
@@ -330,7 +330,7 @@
         "  test_count = int(len(filenames) * test_split)\n",
         "  for i, file in enumerate(filenames):\n",
         "    source_dir, filename = os.path.split(file)\n",
-        "    annot_file = os.path.join(annotations_path, filename.replace(\"jpg\", \"xml\"))\n",
+        "    annot_file = os.path.join(annotations_path, os.path.splitext(filename)[0] + \".xml\")\n",
         "    if i \u003c val_count:\n",
         "      shutil.copy(file, IMAGES_VAL_DIR)\n",
         "      shutil.copy(annot_file, ANNOT_VAL_DIR)\n",


### PR DESCRIPTION
Files containing `jpg` in them like a lot of Roboflow exports have, for example `0AE5531F-906F-461B-88A1-246C569F0E0D_jpg.rf.06d5884d72dac1031f6a6c54370e6492.jpg` where causing the example to search for the annotation in `0AE5531F-906F-461B-88A1-246C569F0E0D_xml.rf.06d5884d72dac1031f6a6c54370e6492.xml` instead of `0AE5531F-906F-461B-88A1-246C569F0E0D_jpg.rf.06d5884d72dac1031f6a6c54370e6492.xml` because all instances of `jpg` where simply being replaced with `xml`.